### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-###Official Game Dev Tycoon Modding API mod
+### Official Game Dev Tycoon Modding API mod
 
 This is the official Modding API mod that ships with Game Dev Tycoon version 1.5.0+
 
@@ -6,7 +6,7 @@ It is a set of [add-on methods and documentation](https://github.com/greenheartg
 
 Pull requests are more than welcome.
 
-##Wiki
+## Wiki
 
 Please check the official documentation at:
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
