### PR TITLE
Reduce the number of iterations in the loops

### DIFF
--- a/api/platforms.js
+++ b/api/platforms.js
@@ -1,35 +1,30 @@
-﻿(function () {
-
+(function () {
 	var checkPlatform = function (platform) {
-		if (!(Checks.checkPropertiesPresent(platform, ['id', 'name', 'startAmount', 'unitsSold', 'licencePrize', 'published', 'platformRetireDate', 'developmentCosts', 'genreWeightings', 'audienceWeightings', 'techLevel', 'iconUri'])
-			&& Checks.checkUniqueness(platform, 'id', Platforms.allPlatforms)
+		if (!(
+			Checks.checkPropertiesPresent(platform, ['id', 'name', 'startAmount', 'unitsSold', 'licencePrize', 'published', 'platformRetireDate', 'developmentCosts', 'genreWeightings', 'audienceWeightings', 'techLevel', 'iconUri'])
 			&& Checks.checkAudienceWeightings(platform.audienceWeightings)
-			&& Checks.checkGenreWeightings(platform.genreWeightings)))
+			&& Checks.checkGenreWeightings(platform.genreWeightings)
+			&& Checks.checkDate(platform.published)
+			&& Checks.checkDate(platform.platformRetireDate)
+			&& Checks.checkUniqueness(platform, 'id', Platforms.allPlatforms)
+			&& (platform.marketPoints ? platform.marketPoints.every(function(mp) { return Checks.checkDate(mp.date) }) : true)
+		)) {
 			return false;
-
-		if (!(Checks.checkDate(platform.published)
-			&& Checks.checkDate(platform.platformRetireDate)))
-			return false;
-
-		if (platform.marketPoints) {
-			for (var i = 0; i < platform.marketPoints.length; i++) {
-				if (!Checks.checkDate(platform.marketPoints[i].date))
-					return false;
-			}
 		}
 
 		return true;
 	};
-
 
 	GDT.addPlatform = function (platform) {
 		if (!checkPlatform(platform))
 			return;
 
 		Platforms.allPlatforms.push(platform);
-		if (platform.events) {
-			for (var i = 0; i < platform.events.length; i++) {
-				GDT.addEvent(platform.events[i]);
+
+		var events = platform.events;
+		if (events) {
+			for (var i = 0, l = events.length; i < l; i++) {
+				GDT.addEvent(events[i]);
 			}
 		}
 	};


### PR DESCRIPTION
Merged two if statements into one to avoid unnecessary comparisons. Used the every method to check every market point's date, instead of manually iterating over them. Moved the platform.events variable to a separate variable to avoid repeated access. Used the length property in the for loop condition to avoid repeated evaluations of events.length.